### PR TITLE
add MenuPool:Remove, this removes the whole pool

### DIFF
--- a/NativeUI/NativeUI.lua
+++ b/NativeUI/NativeUI.lua
@@ -3625,9 +3625,13 @@ function MenuPool:Add(Menu)
 end
 
 function MenuPool:Clear()
-   self = {
-		 Menus = {}
+	self = {
+		Menus = {}
 	 }
+end
+
+function MenuPool:Remove()
+	self = nil
 end
 
 function MenuPool:MouseEdgeEnabled(bool)


### PR DESCRIPTION
This actually doesnt cause the same problems as MenuPool:Clear for some reason, i don't know why

However, using this when re-creating the menu will not cause any memory leaks when just using
```
_menuPool:Remove()
_menuPool = NativeUI.CreatePool()
```

Don't ask me why, i don't know.